### PR TITLE
Fix modelstub and checkstyle

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddScheduleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddScheduleCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/seedu/address/model/ScheduleList.java
+++ b/src/main/java/seedu/address/model/ScheduleList.java
@@ -65,10 +65,10 @@ public class ScheduleList implements ReadOnlyScheduleList {
         // Iterate over the unmodifiable list of meetings
         for (Meeting existingMeeting : meetings.asUnmodifiableObservableList()) {
             if (newMeeting.hasConflictMeeting(existingMeeting)) {
-                return true;  // Conflict detected
+                return true; // Conflict detected
             }
         }
-        return false;  // No conflict
+        return false; // No conflict
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -192,6 +192,11 @@ public class AddCommandTest {
         public void changeWeeklySchedule(Predicate<Meeting> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasMeeting(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request includes several changes to the `AddScheduleCommand` and `AddCommandTest` files to improve the functionality and maintainability of the codebase. The most important changes include removing an unused import and adding a new method to handle meeting checks.

Codebase cleanup:

* [`src/main/java/seedu/address/logic/commands/AddScheduleCommand.java`](diffhunk://#diff-5cad45becad7c7109af213b114b36a427a5e01ce61ef579947a6bc126ceaf86eL5): Removed the unused import statement for `ArrayList`.

Functionality improvements:

* [`src/test/java/seedu/address/logic/commands/AddCommandTest.java`](diffhunk://#diff-b36041d808ad100ab736dfb2e71a3a86faf4d1f01350997b77ba595fccf293ffR195-R199): Added the `hasMeeting` method to the test class to handle meeting checks, ensuring that the method throws an `AssertionError` if called.